### PR TITLE
add pan and zoom to qgraphicsview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pro.user
 *.pro.user*
 *.lnk
+.DS_Store

--- a/OpenSkyStacker.pro
+++ b/OpenSkyStacker.pro
@@ -32,7 +32,8 @@ SOURCES += main.cpp\
     stardetector.cpp \
     pixel.cpp \
     adjoiningpixel.cpp \
-    focas.cpp
+    focas.cpp \
+    stackergraphicsview.cpp
 
 HEADERS  += mainwindow.h \
     imagestacker.h \
@@ -41,7 +42,8 @@ HEADERS  += mainwindow.h \
     stardetector.h \
     pixel.h \
     adjoiningpixel.h \
-    focas.h
+    focas.h \
+    stackergraphicsview.h
 
 FORMS    += mainwindow.ui \
     processingdialog.ui

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -102,7 +102,7 @@ QPushButton:disabled {
          <x>0</x>
          <y>0</y>
          <width>235</width>
-         <height>209</height>
+         <height>208</height>
         </rect>
        </property>
        <attribute name="label">
@@ -227,7 +227,7 @@ QPushButton:disabled {
      </widget>
     </item>
     <item row="0" column="0" rowspan="2">
-     <widget class="QGraphicsView" name="imageHolder">
+     <widget class="StackerGraphicsView" name="imageHolder">
       <property name="styleSheet">
        <string notr="true">background-color: #222;</string>
       </property>
@@ -259,6 +259,13 @@ border-top: 2px solid #555;</string>
   </widget>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>StackerGraphicsView</class>
+   <extends>QGraphicsView</extends>
+   <header>stackergraphicsview.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/stackergraphicsview.cpp
+++ b/stackergraphicsview.cpp
@@ -1,0 +1,75 @@
+#include "stackergraphicsview.h"
+
+StackerGraphicsView::StackerGraphicsView(QWidget *parent):QGraphicsView(parent)
+{
+
+}
+
+void StackerGraphicsView::wheelEvent(QWheelEvent *event)
+{
+    int numDegrees = event->delta() / 8;
+    int numSteps = numDegrees / 15; // see QWheelEvent documentation
+    _numScheduledScalings += numSteps;
+    if (_numScheduledScalings * numSteps < 0) // if user moved the wheel in another direction, we reset previously scheduled scalings
+        _numScheduledScalings = numSteps;
+
+     QTimeLine *anim = new QTimeLine(350, this);
+     anim->setUpdateInterval(20);
+
+     connect(anim, SIGNAL (valueChanged(qreal)), SLOT (scalingTime(qreal)));
+     connect(anim, SIGNAL (finished()), SLOT (animFinished()));
+     anim->start();
+}
+
+void StackerGraphicsView::scalingTime(qreal x)
+{
+ qreal factor = 1.0 + qreal(_numScheduledScalings) / 300.0;
+ scale(factor, factor);
+}
+
+void StackerGraphicsView::animFinished()
+{
+ if (_numScheduledScalings > 0)
+ _numScheduledScalings--;
+ else
+ _numScheduledScalings++;
+ sender()->~QObject();
+}
+
+void StackerGraphicsView::mousePressEvent(QMouseEvent * event) {
+
+    if (event->button() == Qt::LeftButton)
+    {
+        qDebug() << "Start Drag";
+        this->setDragMode(QGraphicsView::ScrollHandDrag);
+        startX = event->x();
+        startY = event->y();
+        this->setInteractive(true);
+        event->accept();
+        return;
+    }
+    QGraphicsView::mousePressEvent(event);
+}
+
+void StackerGraphicsView::mouseReleaseEvent(QMouseEvent *event) {
+    if (event->button() == Qt::LeftButton)
+    {
+        qDebug() << "End Drag";
+        this->setDragMode(QGraphicsView::NoDrag);
+        this->setInteractive(false);
+        event->accept();
+        return;
+    }
+    QGraphicsView::mouseReleaseEvent(event);
+}
+
+void StackerGraphicsView::mouseMoveEvent(QMouseEvent *event) {
+    if (this->dragMode() == QGraphicsView::ScrollHandDrag) {
+        horizontalScrollBar()->setValue(horizontalScrollBar()->value() - (event->x() - startX));
+        verticalScrollBar()->setValue(verticalScrollBar()->value() - (event->y() - startY));
+        startX = event->x();
+        startY = event->y();
+        event->accept();
+        return;
+    }
+}

--- a/stackergraphicsview.h
+++ b/stackergraphicsview.h
@@ -8,6 +8,7 @@
 #include <QWheelEvent>
 #include <QTimeLine>
 #include <QScrollBar>
+#include <QTouchEvent>
 
 class StackerGraphicsView : public QGraphicsView
 {

--- a/stackergraphicsview.h
+++ b/stackergraphicsview.h
@@ -1,0 +1,31 @@
+#ifndef STACKERGRAPHICSVIEW_H
+#define STACKERGRAPHICSVIEW_H
+
+#include <QObject>
+#include <QWidget>
+#include <QGraphicsView>
+#include <QDebug>
+#include <QWheelEvent>
+#include <QTimeLine>
+#include <QScrollBar>
+
+class StackerGraphicsView : public QGraphicsView
+{
+    Q_OBJECT
+
+public:
+    StackerGraphicsView(QWidget *parent = 0);
+private slots:
+    void scalingTime(qreal x);
+    void animFinished();
+private:
+    void wheelEvent(QWheelEvent *event);
+    void mousePressEvent(QMouseEvent *event);
+    void mouseReleaseEvent(QMouseEvent *event);
+    void mouseMoveEvent(QMouseEvent *event);
+    int _numScheduledScalings;
+    int startX;
+    int startY;
+};
+
+#endif // STACKERGRAPHICSVIEW_H


### PR DESCRIPTION
found some info on qt wiki for doing smooth zoom, pan was just using some of the built in features and enabling/disabling them at appropriate times. 

Tested this with a regular mouse, will try it out with mac trackpad tomorrow as I have heard there are some weird issues with QT and macbook trackpad. 