### PR TITLE
Only submit to coveralls on same-repo PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ script:
     qmake -qt=qt5 CONFIG+=coverage &&
     make && make install && ldconfig &&
     bin/oss-test -d ../samples &&
-    coveralls -b libstacker -i libstacker > /dev/null'
+    if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then coveralls -b libstacker -i libstacker > /dev/null; fi'


### PR DESCRIPTION
Travis removes encrypted env vars (such as the Coveralls repo token) with PRs from a downstream repo. Running coveralls in that situation will cause the build to fail.